### PR TITLE
Update to Tomcat 7.0.73 and point to Apache archive site

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,4 @@ A sample Tomcat application integrated with CodeDeploy.
 
 4/24/18 - Making a change #3
 4/27/18 - #1
+4/30 - 1st prod change

--- a/README.md
+++ b/README.md
@@ -2,3 +2,4 @@
 A sample Tomcat application integrated with CodeDeploy. 
 
 4/24/18 - Making a change #3
+4/27/18 - #1

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # aws-codedeploy-sample-tomcat
 A sample Tomcat application integrated with CodeDeploy. 
 
-4/24/18 - Making a change #2
+4/24/18 - Making a change #3

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # aws-codedeploy-sample-tomcat
 A sample Tomcat application integrated with CodeDeploy. 
+
+4/24/18 - Making a change

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # aws-codedeploy-sample-tomcat
 A sample Tomcat application integrated with CodeDeploy. 
 
-4/24/18 - Making a change
+4/24/18 - Making a change #2

--- a/README.md
+++ b/README.md
@@ -4,3 +4,4 @@ A sample Tomcat application integrated with CodeDeploy.
 4/24/18 - Making a change #3
 4/27/18 - #1
 4/30 - 1st prod change
+9/5/19 - Another change for ARN

--- a/scripts/install_dependencies
+++ b/scripts/install_dependencies
@@ -5,11 +5,11 @@ set -e
 CATALINA_HOME=/usr/share/tomcat7-codedeploy
 
 # Tar file name
-TOMCAT7_CORE_TAR_FILENAME='apache-tomcat-7.0.72.tar.gz'
+TOMCAT7_CORE_TAR_FILENAME='apache-tomcat-7.0.73.tar.gz'
 # Download URL for Tomcat7 core
-TOMCAT7_CORE_DOWNLOAD_URL="http://mirror.olnevhost.net/pub/apache/tomcat/tomcat-7/v7.0.72/bin/$TOMCAT7_CORE_TAR_FILENAME"
+TOMCAT7_CORE_DOWNLOAD_URL="https://archive.apache.org/dist/tomcat/tomcat-7/v7.0.73/bin/$TOMCAT7_CORE_TAR_FILENAME"
 # The top-level directory after unpacking the tar file
-TOMCAT7_CORE_UNPACKED_DIRNAME='apache-tomcat-7.0.72'
+TOMCAT7_CORE_UNPACKED_DIRNAME='apache-tomcat-7.0.73'
 
 
 # Check whether there exists a valid instance


### PR DESCRIPTION
The [Explore Continuous Delivery in AWS with the Pipeline Starter Kit](https://aws.amazon.com/blogs/devops/explore-continuous-delivery-in-aws-with-the-pipeline-starter-kit/) continues to break when mirror.olnevhost.net takes down versions of Tomcat that we depend on in this script. Let's leverage archive.apache.org instead.